### PR TITLE
chore: add libc++

### DIFF
--- a/templates/compiler-dev/flake.nix
+++ b/templates/compiler-dev/flake.nix
@@ -38,6 +38,7 @@
               clang-unwrapped
               lld
               llvm
+              libcxx
             ]);
 
           hardeningDisable = ["all"];


### PR DESCRIPTION
Had issues with zig not being linked properly due to differing libc++ between clang and llvm.

```
yamashita@yamashitas-MacBook-Air> stage3/bin/zig version                                                                                                                                                                                                   ~/Projects/zig/build
0.13.0
error: Zig was built/linked incorrectly: LLVM and Clang have separate copies of libc++
       If you are dynamically linking LLVM, make sure you dynamically link libc++ too
```